### PR TITLE
Add export/import scripts, iTerm2 profile, and tooling improvements

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -1,2 +1,3 @@
 # Initialize Homebrew environment (must run before .zshrc)
+export HOMEBREW_NO_ENV_HINTS=1
 eval "$(/opt/homebrew/bin/brew shellenv zsh)"

--- a/.zshrc
+++ b/.zshrc
@@ -19,7 +19,7 @@ zstyle ':omz:update' mode auto
 # zstyle ':omz:update' frequency 13  # days between update checks
 
 # Case-sensitive tab completion (default: case-insensitive)
-# CASE_SENSITIVE="true"
+CASE_SENSITIVE="true"
 
 # Treat hyphens and underscores as interchangeable in completion
 # (only works when CASE_SENSITIVE is not "true")

--- a/Brewfile
+++ b/Brewfile
@@ -18,6 +18,7 @@ brew 'wget'
 
 # Core tools
 brew 'git'
+brew 'gnupg'
 
 # Version and package management
 brew 'asdf'

--- a/Brewfile
+++ b/Brewfile
@@ -27,5 +27,8 @@ brew 'pdm'
 # Build dependencies for asdf-managed languages
 brew 'libyaml'
 
+# Applications
+cask 'iterm2'
+
 # Fonts
 cask 'font-fira-code'

--- a/Brewfile
+++ b/Brewfile
@@ -18,6 +18,7 @@ brew 'wget'
 
 # Core tools
 brew 'git'
+brew 'gh'
 brew 'gnupg'
 
 # Version and package management

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Brewfile               # Homebrew packages (GNU utils, git, asdf, pdm, fonts)
 install.sh             # Bootstrap script for a fresh machine
 update.sh              # Sync packages/tool versions after pulling new dotfile commits
 macos.sh               # System customizations (called by install.sh and update.sh)
+iterm2/
+  jstroop.json         # iTerm2 profile (symlinked to ~/Library/.../DynamicProfiles/)
 export.sh              # Export sensitive keys and secrets to an encrypted bundle
 import.sh              # Import an encrypted bundle from export.sh
 ```
@@ -65,8 +67,9 @@ import.sh              # Import an encrypted bundle from export.sh
 5. Install asdf plugins (python, ruby), generate `.tool-versions` with latest versions on first run, and install them
 6. Symlink `.gitignore_global`, `.gitconfig`, and `.ssh/config`
 7. Symlink `.ssh/config.d/github` and public keys
-8. Apply macOS customizations via [`macos.sh`](macos.sh)
-9. Make deployed dotfiles read-only to prevent accidental edits
+8. Symlink iTerm2 Dynamic Profile to `~/Library/Application Support/iTerm2/DynamicProfiles/`
+9. Apply macOS customizations via [`macos.sh`](macos.sh)
+10. Make deployed dotfiles read-only to prevent accidental edits
 
 ## What's customized
 

--- a/README.md
+++ b/README.md
@@ -23,29 +23,50 @@ Brewfile               # Homebrew packages (GNU utils, git, asdf, pdm, fonts)
 install.sh             # Bootstrap script for a fresh machine
 update.sh              # Sync packages/tool versions after pulling new dotfile commits
 macos.sh               # System customizations (called by install.sh and update.sh)
+export.sh              # Export sensitive keys and secrets to an encrypted bundle
+import.sh              # Import an encrypted bundle from export.sh
 ```
 
 ## Setup
 
-Clone to `~/dotfiles` and run the install script:
+### Fresh machine
 
-```sh
-git clone https://github.com/jpstroop/dotfiles.git ~/dotfiles
-~/dotfiles/install.sh
-exec zsh
-```
+1. Install Xcode Command Line Tools (provides `git`):
+   ```sh
+   xcode-select --install
+   ```
+2. Install Homebrew:
+   ```sh
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+3. Install `gnupg` (needed to decrypt the export bundle):
+   ```sh
+   brew install gnupg
+   ```
+4. Clone via HTTPS (no SSH keys yet):
+   ```sh
+   git clone https://github.com/jpstroop/dotfiles.git ~/dotfiles
+   ```
+5. If moving from another machine, transfer the export bundle and run [`import.sh`](import.sh) to restore SSH keys, GPG keys, and secrets:
+   ```sh
+   ~/dotfiles/import.sh
+   ```
+6. Run [`install.sh`](install.sh):
+   ```sh
+   ~/dotfiles/install.sh
+   exec zsh
+   ```
 
-The install script will:
-1. Install Xcode Command Line Tools (if not already present)
-2. Install Homebrew packages from the Brewfile
-3. Install Oh My Zsh (if not already present)
-4. Symlink `.zprofile`, `.zshrc`, and `.zsh/` into your home directory
-5. Back up any existing files before overwriting
-6. Install asdf plugins (python, ruby), generate `.tool-versions` with latest versions on first run, and install them
-7. Symlink `.ssh/config.d/github` and add an `Include` directive to `~/.ssh/config`
-8. Make deployed dotfiles read-only to prevent accidental edits
-
-Homebrew itself must be installed first: https://brew.sh
+[`install.sh`](install.sh) will:
+1. Install Homebrew packages from the Brewfile
+2. Install Oh My Zsh (if not already present)
+3. Symlink `.zprofile`, `.zshrc`, and `.zsh/` into your home directory
+4. Back up any existing files before overwriting
+5. Install asdf plugins (python, ruby), generate `.tool-versions` with latest versions on first run, and install them
+6. Symlink `.gitignore_global`, `.gitconfig`, and `.ssh/config`
+7. Symlink `.ssh/config.d/github` and public keys
+8. Apply macOS customizations via [`macos.sh`](macos.sh)
+9. Make deployed dotfiles read-only to prevent accidental edits
 
 ## What's customized
 
@@ -123,6 +144,33 @@ To reverse the hidden folders:
 ```sh
 chflags nohidden ~/Music
 ```
+
+## Moving to a new machine
+
+On the old machine, run [`export.sh`](export.sh) to create an encrypted bundle:
+
+```sh
+~/dotfiles/export.sh
+```
+
+It will prompt for an output path (defaults to `~/Desktop/dotfiles-export-<date>.tgz.gpg`)
+and a passphrase. The bundle contains:
+
+- SSH private keys
+- Local `~/.ssh/config.d/` fragments (non-versioned ones like `work`)
+- GPG private keys and owner trust
+- `~/.secrets`
+
+Transfer the bundle to the new machine (AirDrop, USB, etc.), then run
+[`import.sh`](import.sh):
+
+```sh
+~/dotfiles/import.sh
+```
+
+It will prompt for the bundle path and passphrase, restore all files to the
+correct locations with correct permissions, and add the SSH key to the agent.
+Run [`install.sh`](install.sh) afterwards if it's a fresh machine.
 
 ## Development workflow
 

--- a/export.sh
+++ b/export.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+info()   { printf ' \033[35m***\033[0m %s\n' "$1"; }
+warn()   { printf ' \033[33m!!!\033[0m %s\n' "$1"; }
+ok()     { printf ' \033[32m ✓ \033[0m %s\n' "$1"; }
+prompt() { printf ' \033[35m***\033[0m %s ' "$1"; } # no newline; user input follows on the same line
+
+default_output="$HOME/Desktop/dotfiles-export-$(date +%Y%m%d).tgz.gpg"
+prompt "Output file [$default_output]:"
+read -r output_path
+output_path="${output_path:-$default_output}"
+
+tmp=$(mktemp -d)
+trap "rm -rf $tmp" EXIT
+
+# SSH private keys
+info 'Collecting SSH private keys...'
+mkdir -p "$tmp/ssh"
+for key in ~/.ssh/id_*(N); do
+    [[ "$key" == *.pub ]] && continue
+    cp "$key" "$tmp/ssh/"
+    ok "$(basename "$key")"
+done
+
+# Local SSH config.d fragments (skip symlinks — those are versioned in dotfiles)
+info 'Collecting local SSH config fragments...'
+mkdir -p "$tmp/ssh/config.d"
+for fragment in ~/.ssh/config.d/*(N); do
+    [[ -L "$fragment" ]] && continue
+    cp "$fragment" "$tmp/ssh/config.d/"
+    ok "config.d/$(basename "$fragment")"
+done
+
+# GPG private keys
+info 'Collecting GPG keys...'
+mkdir -p "$tmp/gpg"
+if gpg --list-secret-keys --keyid-format LONG 2>/dev/null | grep -q '^sec'; then
+    gpg --export-secret-keys --armor > "$tmp/gpg/private-keys.asc"
+    gpg --export-ownertrust > "$tmp/gpg/owner-trust.txt"
+    ok 'GPG keys exported'
+else
+    warn 'No GPG secret keys found, skipping'
+fi
+
+# ~/.secrets
+info 'Collecting ~/.secrets...'
+if [[ -f ~/.secrets && -s ~/.secrets ]]; then
+    cp ~/.secrets "$tmp/secrets"
+    ok '~/.secrets'
+else
+    warn '~/.secrets is empty or missing, skipping'
+fi
+
+# Encrypt
+info 'Creating encrypted bundle (you will be prompted for a passphrase)...'
+tar -czf - -C "$tmp" . | gpg --symmetric --armor --output "$output_path"
+ok "Bundle saved to $output_path"
+
+echo ''
+info "Transfer $output_path to your new machine and run import.sh"

--- a/import.sh
+++ b/import.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+info()   { printf ' \033[35m***\033[0m %s\n' "$1"; }
+warn()   { printf ' \033[33m!!!\033[0m %s\n' "$1"; }
+ok()     { printf ' \033[32m ✓ \033[0m %s\n' "$1"; }
+prompt() { printf ' \033[35m***\033[0m %s ' "$1"; } # no newline; user input follows on the same line
+
+prompt 'Bundle path:'
+read -r bundle_path
+if [[ ! -f "$bundle_path" ]]; then
+    warn "File not found: $bundle_path"
+    exit 1
+fi
+
+tmp=$(mktemp -d)
+trap "rm -rf $tmp" EXIT
+
+info 'Decrypting bundle (you will be prompted for the passphrase)...'
+gpg --decrypt "$bundle_path" | tar -xzf - -C "$tmp"
+ok 'Bundle decrypted and extracted'
+
+# SSH private keys
+info 'Restoring SSH private keys...'
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+for key in "$tmp"/ssh/*(N); do
+    [[ -d "$key" ]] && continue
+    dest="$HOME/.ssh/$(basename "$key")"
+    if [[ -f "$dest" ]]; then
+        mv "$dest" "${dest}.bak"
+        warn "Backed up existing $(basename "$dest")"
+    fi
+    cp "$key" "$dest"
+    chmod 600 "$dest"
+    ok "$(basename "$key")"
+done
+
+# Local SSH config.d fragments
+if [[ -d "$tmp/ssh/config.d" ]] && (( $(ls "$tmp/ssh/config.d" | wc -l) > 0 )); then
+    info 'Restoring local SSH config fragments...'
+    mkdir -p ~/.ssh/config.d
+    for fragment in "$tmp"/ssh/config.d/*(N); do
+        dest="$HOME/.ssh/config.d/$(basename "$fragment")"
+        if [[ -f "$dest" ]]; then
+            mv "$dest" "${dest}.bak"
+            warn "Backed up existing $(basename "$fragment")"
+        fi
+        cp "$fragment" "$dest"
+        ok "config.d/$(basename "$fragment")"
+    done
+fi
+
+# GPG keys
+if [[ -f "$tmp/gpg/private-keys.asc" ]]; then
+    info 'Restoring GPG keys...'
+    gpg --import "$tmp/gpg/private-keys.asc"
+    gpg --import-ownertrust "$tmp/gpg/owner-trust.txt"
+    ok 'GPG keys imported'
+fi
+
+# ~/.secrets
+if [[ -f "$tmp/secrets" ]]; then
+    info 'Restoring ~/.secrets...'
+    if [[ -f ~/.secrets && -s ~/.secrets ]]; then
+        mv ~/.secrets ~/.secrets.bak
+        warn 'Backed up existing ~/.secrets'
+    fi
+    cp "$tmp/secrets" ~/.secrets
+    chmod 600 ~/.secrets
+    ok '~/.secrets restored'
+fi
+
+# Add SSH key to agent
+if [[ -f ~/.ssh/id_ed25519 ]]; then
+    info 'Adding SSH key to agent...'
+    ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+    ok 'SSH key added to agent'
+fi
+
+echo ''
+info 'Done! Run install.sh if this is a fresh machine, or exec zsh to reload your shell.'

--- a/install.sh
+++ b/install.sh
@@ -136,7 +136,7 @@ fi
 ln -sfn "$DOTFILES_DIR/.gitignore_global" "$HOME/.gitignore"
 ok '.gitignore_global symlinked to ~/.gitignore'
 
-# 15. Symlink .gitconfig
+# 14. Symlink .gitconfig
 info 'Symlinking .gitconfig...'
 if [[ -f "$HOME/.gitconfig" && ! -L "$HOME/.gitconfig" ]]; then
     mv "$HOME/.gitconfig" "$HOME/.gitconfig.bak"
@@ -145,7 +145,7 @@ fi
 ln -sfn "$DOTFILES_DIR/.gitconfig" "$HOME/.gitconfig"
 ok '.gitconfig symlinked'
 
-# 14. Set up SSH config
+# 15. Set up SSH config
 info 'Setting up SSH config...'
 mkdir -p "$HOME/.ssh/config.d"
 chmod 700 "$HOME/.ssh" "$HOME/.ssh/config.d"
@@ -162,10 +162,16 @@ for pubkey in "$DOTFILES_DIR"/.ssh/*.pub; do
 done
 ok 'SSH public keys symlinked'
 
-# 16. Apply macOS customizations
+# 16. Symlink iTerm2 Dynamic Profile
+info 'Symlinking iTerm2 profile...'
+mkdir -p "$HOME/Library/Application Support/iTerm2/DynamicProfiles"
+ln -sfn "$DOTFILES_DIR/iterm2/jstroop.json" "$HOME/Library/Application Support/iTerm2/DynamicProfiles/jstroop.json"
+ok 'iTerm2 profile symlinked'
+
+# 17. Apply macOS customizations
 "$DOTFILES_DIR/macos.sh"
 
-# 17. Make deployed dotfiles read-only to prevent accidental edits
+# 18. Make deployed dotfiles read-only to prevent accidental edits
 info 'Making deployed dotfiles read-only...'
 chmod a-w "$DOTFILES_DIR/.zprofile" "$DOTFILES_DIR/.zshrc" "$DOTFILES_DIR/.gitconfig" "$DOTFILES_DIR/.gitignore_global"
 find "$DOTFILES_DIR/.zsh" -type f -exec chmod a-w {} +

--- a/iterm2/jstroop.json
+++ b/iterm2/jstroop.json
@@ -1,0 +1,611 @@
+{
+"Profiles": [
+{
+  "Ansi 7 Color (Light)" : {
+    "Red Component" : 0.7810397744178772,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78104829788208008,
+    "Alpha Component" : 1,
+    "Green Component" : 0.78105825185775757
+  },
+  "Ansi 15 Color (Light)" : {
+    "Red Component" : 0.99999600648880005,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Ansi 2 Color (Light)" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.7607843279838562
+  },
+  "Bold Color" : {
+    "Red Component" : 0.062745101749897003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.062745101749897003,
+    "Alpha Component" : 1,
+    "Green Component" : 0.062745101749897003
+  },
+  "Ansi 1 Color (Dark)" : {
+    "Red Component" : 0.7074432373046875,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.16300037503242493,
+    "Alpha Component" : 1,
+    "Green Component" : 0.23660069704055786
+  },
+  "Use Bright Bold" : true,
+  "Ansi 9 Color (Light)" : {
+    "Red Component" : 0.8659515380859375,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.45833224058151245,
+    "Alpha Component" : 1,
+    "Green Component" : 0.47524076700210571
+  },
+  "Ansi 8 Color (Dark)" : {
+    "Red Component" : 0.40781760215759277,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.4078223705291748,
+    "Alpha Component" : 1,
+    "Green Component" : 0.40782788395881653
+  },
+  "Background Color" : {
+    "Red Component" : 0.97999999999999998,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.97999999999999998,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97999999999999998
+  },
+  "Columns" : 100,
+  "Ansi 8 Color" : {
+    "Red Component" : 0.40781760215759277,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.4078223705291748,
+    "Alpha Component" : 1,
+    "Green Component" : 0.40782788395881653
+  },
+  "Right Option Key Sends" : 0,
+  "Ansi 4 Color (Light)" : {
+    "Red Component" : 0.15404300391674042,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78216177225112915,
+    "Alpha Component" : 1,
+    "Green Component" : 0.26474356651306152
+  },
+  "Blinking Cursor" : false,
+  "Selected Text Color (Light)" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0
+  },
+  "Selected Text Color (Dark)" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0
+  },
+  "Ansi 3 Color (Dark)" : {
+    "Red Component" : 0.78058648109436035,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.76959484815597534
+  },
+  "Keyboard Map" : {
+
+  },
+  "Visual Bell" : true,
+  "Cursor Text Color" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Scrollback Lines" : 1000,
+  "Selection Color (Light)" : {
+    "Red Component" : 0.70196080207824707,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.84313726425170898
+  },
+  "Ansi 0 Color" : {
+    "Red Component" : 0.078431375324726105,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.11764705926179886,
+    "Alpha Component" : 1,
+    "Green Component" : 0.098039217293262482
+  },
+  "Ansi 11 Color (Light)" : {
+    "Red Component" : 0.9259033203125,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.8833775520324707
+  },
+  "Ansi 5 Color (Dark)" : {
+    "Red Component" : 0.752197265625,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.74494361877441406,
+    "Alpha Component" : 1,
+    "Green Component" : 0.24931684136390686
+  },
+  "Cursor Text Color (Light)" : {
+    "Red Component" : 1,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Silence Bell" : true,
+  "Rows" : 40,
+  "Guid" : "7440F7FD-B31F-4B39-8171-ABCFAEE4ADD1",
+  "Ansi 14 Color (Dark)" : {
+    "Red Component" : 0.37597531080245972,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.99263292551040649
+  },
+  "Ansi 15 Color (Dark)" : {
+    "Red Component" : 0.99999600648880005,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Ansi 0 Color (Dark)" : {
+    "Red Component" : 0.078431375324726105,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.11764705926179886,
+    "Alpha Component" : 1,
+    "Green Component" : 0.098039217293262482
+  },
+  "Ambiguous Double Width" : false,
+  "Option Key Sends" : 0,
+  "Ansi 3 Color" : {
+    "Red Component" : 0.78058648109436035,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.76959484815597534
+  },
+  "Window Type" : 0,
+  "BM Growl" : true,
+  "Prompt Before Closing 2" : false,
+  "Command" : "",
+  "Selected Text Color" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0
+  },
+  "Ansi 14 Color (Light)" : {
+    "Red Component" : 0.37597531080245972,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.99263292551040649
+  },
+  "Automatically Enable Alternate Mouse Scroll" : true,
+  "Cursor Guide Color (Dark)" : {
+    "Red Component" : 0.37649588016392954,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.94099044799804688,
+    "Alpha Component" : 0.25,
+    "Green Component" : 0.80232617749205526
+  },
+  "Send Code When Idle" : false,
+  "Ansi 6 Color" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78166204690933228,
+    "Alpha Component" : 1,
+    "Green Component" : 0.77425903081893921
+  },
+  "Jobs to Ignore" : [
+    "rlogin",
+    "ssh",
+    "slogin",
+    "telnet"
+  ],
+  "Badge Color (Dark)" : {
+    "Red Component" : 0.9787440299987793,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.65218597462148864,
+    "Alpha Component" : 0.5,
+    "Green Component" : 0.65218597462148864
+  },
+  "Cursor Color" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0
+  },
+  "Vertical Spacing" : 1,
+  "Disable Window Resizing" : true,
+  "Close Sessions On End" : true,
+  "Selection Color (Dark)" : {
+    "Red Component" : 0.70196080207824707,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.84313726425170898
+  },
+  "Default Bookmark" : "No",
+  "Foreground Color (Light)" : {
+    "Red Component" : 0.062745098039215685,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.062745098039215685,
+    "Alpha Component" : 1,
+    "Green Component" : 0.062745098039215685
+  },
+  "Custom Command" : "No",
+  "Background Color (Dark)" : {
+    "Red Component" : 0,
+    "Color Space" : "P3",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0
+  },
+  "Ansi 9 Color" : {
+    "Red Component" : 0.8659515380859375,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.45833224058151245,
+    "Alpha Component" : 1,
+    "Green Component" : 0.47524076700210571
+  },
+  "Ansi 14 Color" : {
+    "Red Component" : 0.37597531080245972,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.99263292551040649
+  },
+  "Flashing Bell" : false,
+  "Use Italic Font" : true,
+  "Ansi 13 Color (Dark)" : {
+    "Red Component" : 0.8821563720703125,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.8821563720703125,
+    "Alpha Component" : 1,
+    "Green Component" : 0.4927266538143158
+  },
+  "Cursor Guide Color (Light)" : {
+    "Red Component" : 0.52338262643729649,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.85319280624389648,
+    "Alpha Component" : 0.25,
+    "Green Component" : 0.77217718629089516
+  },
+  "Ansi 12 Color" : {
+    "Red Component" : 0.65349078178405762,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.9485321044921875,
+    "Alpha Component" : 1,
+    "Green Component" : 0.67044717073440552
+  },
+  "Ansi 10 Color (Light)" : {
+    "Red Component" : 0.3450070321559906,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.56541937589645386,
+    "Alpha Component" : 1,
+    "Green Component" : 0.9042816162109375
+  },
+  "Non-ASCII Anti Aliased" : true,
+  "Ansi 10 Color" : {
+    "Red Component" : 0.3450070321559906,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.56541937589645386,
+    "Alpha Component" : 1,
+    "Green Component" : 0.9042816162109375
+  },
+  "Foreground Color" : {
+    "Red Component" : 0.062745101749897003,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.062745101749897003,
+    "Alpha Component" : 1,
+    "Green Component" : 0.062745101749897003
+  },
+  "Link Color (Light)" : {
+    "Red Component" : 0.19802422821521759,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.9337158203125,
+    "Alpha Component" : 1,
+    "Green Component" : 0.55789834260940552
+  },
+  "Description" : "Default",
+  "Ansi 7 Color (Dark)" : {
+    "Red Component" : 0.7810397744178772,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78104829788208008,
+    "Alpha Component" : 1,
+    "Green Component" : 0.78105825185775757
+  },
+  "Sync Title" : false,
+  "Ansi 1 Color" : {
+    "Red Component" : 0.7074432373046875,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.16300037503242493,
+    "Alpha Component" : 1,
+    "Green Component" : 0.23660069704055786
+  },
+  "Name" : "jstroop",
+  "Transparency" : 0,
+  "Horizontal Spacing" : 1,
+  "Cursor Color (Dark)" : {
+    "Red Component" : 0,
+    "Color Space" : "P3",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.76078431372549016
+  },
+  "Ansi 2 Color (Dark)" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.7607843279838562
+  },
+  "Ansi 9 Color (Dark)" : {
+    "Red Component" : 0.8659515380859375,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.45833224058151245,
+    "Alpha Component" : 1,
+    "Green Component" : 0.47524076700210571
+  },
+  "Badge Color" : {
+    "Red Component" : 0.74613857269287109,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.11610633134841919,
+    "Alpha Component" : 0.5,
+    "Green Component" : 0.11610633134841919
+  },
+  "Ansi 13 Color (Light)" : {
+    "Red Component" : 0.8821563720703125,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.8821563720703125,
+    "Alpha Component" : 1,
+    "Green Component" : 0.4927266538143158
+  },
+  "Idle Code" : 0,
+  "Ansi 4 Color" : {
+    "Red Component" : 0.15404300391674042,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78216177225112915,
+    "Alpha Component" : 1,
+    "Green Component" : 0.26474356651306152
+  },
+  "Bold Color (Dark)" : {
+    "Red Component" : 0.99999600648880005,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Screen" : -1,
+  "Ansi 4 Color (Dark)" : {
+    "Red Component" : 0.15404300391674042,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78216177225112915,
+    "Alpha Component" : 1,
+    "Green Component" : 0.26474356651306152
+  },
+  "Cursor Text Color (Dark)" : {
+    "Red Component" : 0,
+    "Color Space" : "P3",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0
+  },
+  "Selection Color" : {
+    "Red Component" : 0.70196080207824707,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 0.84313726425170898
+  },
+  "Use Non-ASCII Font" : false,
+  "Badge Color (Light)" : {
+    "Red Component" : 0.74613857269287109,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.11610633058398889,
+    "Alpha Component" : 0.5,
+    "Green Component" : 0.11610633058398889
+  },
+  "Character Encoding" : 4,
+  "Ansi 11 Color (Dark)" : {
+    "Red Component" : 0.9259033203125,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.8833775520324707
+  },
+  "Bold Color (Light)" : {
+    "Red Component" : 0.062745098039215685,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.062745098039215685,
+    "Alpha Component" : 1,
+    "Green Component" : 0.062745098039215685
+  },
+  "Ansi 12 Color (Dark)" : {
+    "Red Component" : 0.65349078178405762,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.9485321044921875,
+    "Alpha Component" : 1,
+    "Green Component" : 0.67044717073440552
+  },
+  "Faint Text Alpha (Dark)" : 0.6100000000000001,
+  "Ansi 7 Color" : {
+    "Red Component" : 0.7810397744178772,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78104829788208008,
+    "Alpha Component" : 1,
+    "Green Component" : 0.78105825185775757
+  },
+  "Ansi 6 Color (Dark)" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78166204690933228,
+    "Alpha Component" : 1,
+    "Green Component" : 0.77425903081893921
+  },
+  "Non Ascii Font" : "Monaco 12",
+  "Cursor Guide Color" : {
+    "Red Component" : 0.52338260412216187,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.85319280624389648,
+    "Alpha Component" : 0.25,
+    "Green Component" : 0.77217715978622437
+  },
+  "Custom Directory" : "No",
+  "ASCII Anti Aliased" : true,
+  "Shortcut" : "",
+  "Mouse Reporting" : true,
+  "Tags" : [
+
+  ],
+  "Ansi 6 Color (Light)" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.78166204690933228,
+    "Alpha Component" : 1,
+    "Green Component" : 0.77425903081893921
+  },
+  "Background Image Location" : "",
+  "Ansi 1 Color (Light)" : {
+    "Red Component" : 0.7074432373046875,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.16300037503242493,
+    "Alpha Component" : 1,
+    "Green Component" : 0.23660069704055786
+  },
+  "Use Bold Font" : true,
+  "Ansi 8 Color (Light)" : {
+    "Red Component" : 0.40781760215759277,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.4078223705291748,
+    "Alpha Component" : 1,
+    "Green Component" : 0.40782788395881653
+  },
+  "Ansi 2 Color" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.7607843279838562
+  },
+  "Normal Font" : "Monaco 13",
+  "Unlimited Scrollback" : false,
+  "Ansi 12 Color (Light)" : {
+    "Red Component" : 0.65349078178405762,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.9485321044921875,
+    "Alpha Component" : 1,
+    "Green Component" : 0.67044717073440552
+  },
+  "Ansi 10 Color (Dark)" : {
+    "Red Component" : 0.3450070321559906,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.56541937589645386,
+    "Alpha Component" : 1,
+    "Green Component" : 0.9042816162109375
+  },
+  "Ansi 3 Color (Light)" : {
+    "Red Component" : 0.78058648109436035,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.76959484815597534
+  },
+  "Cursor Color (Light)" : {
+    "Red Component" : 0,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0
+  },
+  "Ansi 15 Color" : {
+    "Red Component" : 0.99999600648880005,
+    "Color Space" : "sRGB",
+    "Blue Component" : 1,
+    "Alpha Component" : 1,
+    "Green Component" : 1
+  },
+  "Blur" : false,
+  "Use Separate Colors for Light and Dark Mode" : true,
+  "Background Color (Light)" : {
+    "Red Component" : 0.97999999999999998,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.97999999999999998,
+    "Alpha Component" : 1,
+    "Green Component" : 0.97999999999999998
+  },
+  "Terminal Type" : "xterm-256color",
+  "Ansi 13 Color" : {
+    "Red Component" : 0.8821563720703125,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.8821563720703125,
+    "Alpha Component" : 1,
+    "Green Component" : 0.4927266538143158
+  },
+  "Ansi 5 Color (Light)" : {
+    "Red Component" : 0.752197265625,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.74494361877441406,
+    "Alpha Component" : 1,
+    "Green Component" : 0.24931684136390686
+  },
+  "Foreground Color (Dark)" : {
+    "Red Component" : 0,
+    "Color Space" : "P3",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.76078431372549016
+  },
+  "Link Color" : {
+    "Red Component" : 0.19802422821521759,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.9337158203125,
+    "Alpha Component" : 1,
+    "Green Component" : 0.55789834260940552
+  },
+  "Link Color (Dark)" : {
+    "Red Component" : 0.19802422821521759,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.9337158203125,
+    "Alpha Component" : 1,
+    "Green Component" : 0.55789834260940552
+  },
+  "Ansi 11 Color" : {
+    "Red Component" : 0.9259033203125,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0,
+    "Alpha Component" : 1,
+    "Green Component" : 0.8833775520324707
+  },
+  "Ansi 5 Color" : {
+    "Red Component" : 0.752197265625,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.74494361877441406,
+    "Alpha Component" : 1,
+    "Green Component" : 0.24931684136390686
+  },
+  "Ansi 0 Color (Light)" : {
+    "Red Component" : 0.078431375324726105,
+    "Color Space" : "sRGB",
+    "Blue Component" : 0.11764705926179886,
+    "Alpha Component" : 1,
+    "Green Component" : 0.098039217293262482
+  }
+}
+]
+}


### PR DESCRIPTION
- Add `export.sh` / `import.sh` for migrating SSH keys, GPG keys, and `~/.secrets` between machines via GPG-encrypted bundle
- Add iTerm2 Dynamic Profile (`iterm2/jstroop.json`) symlinked into `~/Library/Application Support/iTerm2/DynamicProfiles/`
- Add `gh` and `gnupg` to Brewfile; add `cask 'iterm2'`
- Add `HOMEBREW_NO_ENV_HINTS=1` to `.zprofile`
- Update `install.sh` to symlink iTerm2 profile
- Update README with "Moving to a new machine" workflow and fresh machine bootstrap order